### PR TITLE
typed user

### DIFF
--- a/src/client/core/api/auth.ts
+++ b/src/client/core/api/auth.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs/Observable';
 import { HttpService } from 'client/core/http.service';
 
 // Internal Types
+import { GetMeResponse } from 'server/api/auth/models';
 
 export class AuthApi {
   base = 'auth';
@@ -13,7 +14,7 @@ export class AuthApi {
     private API_ROOT: string,
     private http: HttpService) { }
 
-  getMe = (): Observable<any> => {
+  getMe = (): Observable<GetMeResponse> => {
     return this.http.get(`${ this.API_ROOT }/auth/me`);
   };
 }

--- a/src/client/core/user.service.ts
+++ b/src/client/core/user.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 import { ApiService } from 'client/core/api/api.service';
 
 // Internal Types
-import { User } from 'server/api/models';
+import { User } from 'server/api/auth/models';
 
 @Injectable()
 

--- a/src/client/core/user.service.ts
+++ b/src/client/core/user.service.ts
@@ -5,11 +5,13 @@ import { Injectable } from '@angular/core';
 import { ApiService } from 'client/core/api/api.service';
 
 // Internal Types
+import { User } from 'server/api/models';
 
 @Injectable()
 
 export class UserService {
-  user: any;
+  user: User;
+  isAdmin: boolean;
 
   constructor(
     private apiService: ApiService
@@ -20,6 +22,7 @@ export class UserService {
       .subscribe(
         data => {
           this.user = data.user;
+          this.isAdmin = !!this.user.roles.find(role => role === 'admin');
         },
         error => this.handleHttpError(error)
       );

--- a/src/server/api/auth/models.ts
+++ b/src/server/api/auth/models.ts
@@ -1,16 +1,23 @@
 // External Dependencies
+import { Request } from 'express';
 
-// Internal Dependencies
-import { AuthenticatedRequest, User as GeneralUser } from '../models';
+export interface User {
+  id: string;
 
-// Internal Types
+  name: {
+    first: string;
+    last: string;
+  };
 
-export type AuthUser = GeneralUser;
+  email: string;
+  
+  roles: string[];
+}
 
-export interface GetMeRequest extends AuthenticatedRequest {
-
+export interface GetMeRequest extends Request {
+  user: User;
 }
 
 export interface GetMeResponse {
-  user: AuthUser;
+  user: User;
 }

--- a/src/server/api/auth/models.ts
+++ b/src/server/api/auth/models.ts
@@ -1,0 +1,16 @@
+// External Dependencies
+
+// Internal Dependencies
+import { AuthenticatedRequest, User as GeneralUser } from '../models';
+
+// Internal Types
+
+export type AuthUser = GeneralUser;
+
+export interface GetMeRequest extends AuthenticatedRequest {
+
+}
+
+export interface GetMeResponse {
+  user: AuthUser;
+}

--- a/src/server/api/auth/routes.ts
+++ b/src/server/api/auth/routes.ts
@@ -14,11 +14,7 @@ export const getMe = async (req: GetMeRequest, res: Response) => {
     const data: GetMeResponse = { user };
     return res.json(data);
   } catch (error) {
-    return res.status(500).json({
-      error,
-      stack: error.stack,
-      endpoint: `auth.getMe`
-    });
+    return res.status(500).json({ error });
   }
 }
 

--- a/src/server/api/auth/routes.ts
+++ b/src/server/api/auth/routes.ts
@@ -1,15 +1,18 @@
 // External Dependencies
+import { Response } from 'express';
 
 // Internal Dependencies
 import { fetchUser } from './helpers';
 
 // Internal Types
+import { GetMeRequest, GetMeResponse} from './models';
 
-export const getMe = async (req, res) => {
+export const getMe = async (req: GetMeRequest, res: Response) => {
   try {
     const user = await fetchUser({ id: req.user.id });
 
-    return res.json({ user });
+    const data: GetMeResponse = { user };
+    return res.json(data);
   } catch (error) {
     return res.status(500).json({
       error,

--- a/src/server/api/helpers.ts
+++ b/src/server/api/helpers.ts
@@ -3,8 +3,10 @@
 // Internal Dependencies
 
 // Internal Types
+import { User } from './models';
 
-export const mockLoggedInUser = () => ({
+export const mockLoggedInUser = (): User => ({
+  id: 'id123',
   name: {
     first: 'Test',
     last: 'User'

--- a/src/server/api/helpers.ts
+++ b/src/server/api/helpers.ts
@@ -3,7 +3,7 @@
 // Internal Dependencies
 
 // Internal Types
-import { User } from './models';
+import { User } from './auth/models';
 
 export const mockLoggedInUser = (): User => ({
   id: 'id123',

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -1,0 +1,23 @@
+// External Dependencies
+import { Request } from 'express';
+
+// Internal Dependencies
+
+// Internal Types
+
+export interface User {
+  id: string;
+
+  name: {
+    first: string;
+    last: string;
+  };
+
+  email: string;
+  
+  roles: string[];
+}
+
+export interface AuthenticatedRequest extends Request {
+  user: User;
+}

--- a/src/server/api/models.ts
+++ b/src/server/api/models.ts
@@ -4,20 +4,3 @@ import { Request } from 'express';
 // Internal Dependencies
 
 // Internal Types
-
-export interface User {
-  id: string;
-
-  name: {
-    first: string;
-    last: string;
-  };
-
-  email: string;
-  
-  roles: string[];
-}
-
-export interface AuthenticatedRequest extends Request {
-  user: User;
-}

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -10,10 +10,6 @@
     "removeComments": true,
     "baseUrl": "../../",
     "paths": {
-      "dependencies/*": [
-        "src/server/dependencies/*",
-        "*"
-      ],
       "shared/*": [
         "src/shared/*",
         "*"


### PR DESCRIPTION
setup:

1) `yarn install`
2) `npm run client-dev`
3) `npm run start-server`
4) visit `localhost:8080` (dont really need the GUI for our purposes here)

This branch is the first that showcases how to share models across the front and backend to preserve API contracts.

If you take a look at `src/client/core/user.service.ts`, it makes a call to the API service's `auth.getMe()` function. With abstraction this far out, it's often hard to tell at what point in the chain your contract with your server might have been broken. 

But, typescript will let us know if that happens! in `client/core/api/api.service.ts`, we import a "model" that is shared between the backend and the frontend (using webpack aliases to easily import from the server). The user model can be found in `server/api/models.ts`.

This model gets imported in the various helpers and `server/api/auth/routes.ts`, where the `getMe()` endpoint lives. If at any point the structure of a user changes, or the structure of the response that this endpoint sends back changes, and we improperly use this data on the frontend, our app won't even compile.